### PR TITLE
feature/CA-001 Instalación de React

### DIFF
--- a/decide/booth/urls.py
+++ b/decide/booth/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 from .views import BoothView
+from django.views.generic import TemplateView
 
 
 urlpatterns = [
     path('<int:voting_id>/', BoothView.as_view()),
+    path('', TemplateView.as_view(template_name='index.html'))
 ]

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -84,10 +84,13 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'decide.urls'
 
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, 'booth/decide-react/build/')
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -157,6 +160,10 @@ TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
 
 STATIC_URL = '/static/'
+
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'booth/decide-react/build/static/')
+]
 
 # number of bits for the key, all auths should use the same number of bits
 KEYBITS = 256

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ djangorestframework==3.7.7
 django-cors-headers==2.1.0
 requests==2.18.4
 django-filter==1.1.0
-psycopg2==2.7.4
+psycopg2==2.8.4
 django-rest-swagger==2.2.0
 coverage==4.5.2
 django-nose==1.4.6


### PR DESCRIPTION
Cambio de la configuración del proyecto de base para su correcto funcionamiento en Ubuntu 20.04. Se ha instalado React y sus dependencias y se ha añadido una vista de prueba cuando accedemos a localhost:8000/booth que demuestra que React está funcionando