### PR TITLE
feature/CA-023 Cambiada la URL para acceder al login

### DIFF
--- a/decide/booth/urls.py
+++ b/decide/booth/urls.py
@@ -4,5 +4,5 @@ from django.views.generic import TemplateView
 
 
 urlpatterns = [
-    path('<int:voting_id>/', BoothView.as_view()),
+    path('', BoothView.as_view()),
 ]

--- a/decide/booth/views.py
+++ b/decide/booth/views.py
@@ -10,22 +10,3 @@ from base import mods
 class BoothView(TemplateView):
     template_name = 'index.html'
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        vid = kwargs.get('voting_id', 0)
-
-        try:
-            r = mods.get('voting', params={'id': vid})
-
-            # Casting numbers to string to manage in javascript with BigInt
-            # and avoid problems with js and big number conversion
-            for k, v in r[0]['pub_key'].items():
-                r[0]['pub_key'][k] = str(v)
-
-            context['voting'] = json.dumps(r[0])
-        except:
-            raise Http404
-
-        context['KEYBITS'] = settings.KEYBITS
-        #Cambiado para react
-        return context


### PR DESCRIPTION
Se ha cambiado la URL para acceder a Booth. Ya no es necesario añadir la ID de la votación